### PR TITLE
Colum resizing

### DIFF
--- a/examples/inno-day-table/src/App.js
+++ b/examples/inno-day-table/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useTable, usePagination, useRowSelect, useExpanded, useFilters, useResizeColumns, useBlockLayout } from 'react-table'
+import { useTable, usePagination, useRowSelect, useExpanded, useFilters, useResizeColumns, useFlexLayout } from 'react-table'
 import { FiChevronDown, FiChevronRight } from "react-icons/fi";
 
 import { EditableCell } from './EditableCell'
@@ -114,7 +114,7 @@ function Table({ columns, data, updateMyData }) {
     usePagination,
     useRowSelect,
     useResizeColumns,
-    useBlockLayout,
+    useFlexLayout,
     hooks => {
       hooks.visibleColumns.push(columns => [
         {
@@ -136,7 +136,9 @@ function Table({ columns, data, updateMyData }) {
                 {row.isExpanded ? <FiChevronDown /> : <FiChevronRight />}
               </span>
             ) : null
-          )
+          ),
+          minWidth: 25,
+          disableResizing: true,
         },
         // Let's make a column for selection
         {
@@ -155,6 +157,8 @@ function Table({ columns, data, updateMyData }) {
               <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
             </div>
           ),
+          width: 25,
+          disableResizing: true,
         },
         ...columns,
       ])

--- a/examples/inno-day-table/src/App.js
+++ b/examples/inno-day-table/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useTable, usePagination, useRowSelect, useExpanded, useFilters } from 'react-table'
+import { useTable, usePagination, useRowSelect, useExpanded, useFilters, useResizeColumns, useBlockLayout } from 'react-table'
 import { FiChevronDown, FiChevronRight } from "react-icons/fi";
 
 import { EditableCell } from './EditableCell'
@@ -39,6 +39,7 @@ const Styles = styled.div`
         padding: 0;
         margin: 0;
         border: 0;
+        max-width: 100%;
       }
     }
   }
@@ -70,6 +71,9 @@ function Table({ columns, data, updateMyData }) {
   const filterTypes = useFilterTypes();
   const defaultColumn = React.useMemo(
     () => ({
+      minWidth: 30,
+      width: 150,
+      maxWidth: 400,
       // Let's set up our default Filter UI
       Filter: DefaultColumnFilter,
       Cell: EditableCell,
@@ -109,6 +113,8 @@ function Table({ columns, data, updateMyData }) {
     useExpanded,
     usePagination,
     useRowSelect,
+    useResizeColumns,
+    useBlockLayout,
     hooks => {
       hooks.visibleColumns.push(columns => [
         {

--- a/examples/inno-day-table/src/App.js
+++ b/examples/inno-day-table/src/App.js
@@ -7,6 +7,7 @@ import { EditableCell } from './EditableCell'
 import makeData from './makeData'
 import { ColumnHeader } from './ColumnHeader'
 import { useFilterTypes, DefaultColumnFilter, SelectColumnFilter } from './filtering'
+import { calculateExpandedLevels } from './calculateExpandedLevels';
 
 const Styles = styled.div`
   padding: 1rem;
@@ -116,7 +117,7 @@ function Table({ columns, data, updateMyData }) {
     useResizeColumns,
     useFlexLayout,
     hooks => {
-      hooks.visibleColumns.push(columns => [
+      hooks.visibleColumns.push((columns, meta) => [
         {
           id: 'expander',
           Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }) => (
@@ -164,6 +165,8 @@ function Table({ columns, data, updateMyData }) {
       ])
     }
   )
+
+  console.log(`Expanded levels: ${calculateExpandedLevels(expanded)}`);
 
   // Render the UI for your table
   return (

--- a/examples/inno-day-table/src/ColumnHeader.js
+++ b/examples/inno-day-table/src/ColumnHeader.js
@@ -32,7 +32,7 @@ export const ColumnHeader = (props) => {
                     <button onClick={() => setIsFiltering(false)}>❌</button>
                 </>
             )}
-            <Resizer {...props.getResizerProps()} isResizing={props.isResizing} />
+            {props.getResizerProps && <Resizer {...props.getResizerProps()} isResizing={props.isResizing} />}
         </th>
     )
 }

--- a/examples/inno-day-table/src/ColumnHeader.js
+++ b/examples/inno-day-table/src/ColumnHeader.js
@@ -1,4 +1,18 @@
 import React from 'react';
+import styled from 'styled-components'
+
+const Resizer = styled.span`
+    background-color: ${(props) => props.isResizing ? "lightBlue" : "lightGrey"};    
+    display: inline-block;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    touch-action: none;
+    transform: translateX(50%);
+    width: 10px;
+    z-index: 1;
+`;
 
 export const ColumnHeader = (props) => {
     const [isFiltering, setIsFiltering] = React.useState(false);
@@ -18,6 +32,7 @@ export const ColumnHeader = (props) => {
                     <button onClick={() => setIsFiltering(false)}>❌</button>
                 </>
             )}
+            <Resizer {...props.getResizerProps()} isResizing={props.isResizing} />
         </th>
     )
 }

--- a/examples/inno-day-table/src/calculateExpandedLevels.js
+++ b/examples/inno-day-table/src/calculateExpandedLevels.js
@@ -1,0 +1,8 @@
+export function calculateExpandedLevels(expanded) {
+  const rowIds = Object.keys(expanded);
+  if (rowIds.length === 0) {
+    return 0;
+  }
+
+  return Math.max(...rowIds.map((rowId) => rowId.split(".").length))
+}


### PR DESCRIPTION
- Include the resize hook and one of the non-table layouts (we could have a conversation about which layout would be best in DGC as we could benefit from using Flex or Grid layout but IE11 compatibility has to stay in mind)
- Default sizing options for all columns, could be customized on a per-column basis including disabling resize
- Resizer component to handle the display of the resizing element

Fixes #5